### PR TITLE
Fix update function in `eprop_iaf_psc_delta` models

### DIFF
--- a/models/eprop_iaf_psc_delta.cpp
+++ b/models/eprop_iaf_psc_delta.cpp
@@ -313,17 +313,17 @@ eprop_iaf_psc_delta::update( Time const& origin, const long from, const long to 
   {
     const long t = origin.get_steps() + lag;
 
-    const auto z_in = B_.spikes_.get_value( lag );
+    auto z_in = B_.spikes_.get_value( lag );
 
     if ( S_.r_ == 0 ) // not refractory, can spike
     {
-      S_.v_m_ = V_.P_i_in_ * ( S_.i_in_ + P_.I_e_ ) + V_.P_v_m_ * S_.v_m_ + z_in;
-
       if ( P_.with_refr_input_ and S_.refr_spikes_buffer_ != 0.0 )
       {
-        S_.v_m_ += S_.refr_spikes_buffer_;
+        z_in += S_.refr_spikes_buffer_;
         S_.refr_spikes_buffer_ = 0.0;
       }
+
+      S_.v_m_ = V_.P_i_in_ * ( S_.i_in_ + P_.I_e_ ) + V_.P_v_m_ * S_.v_m_ + z_in;
 
       S_.v_m_ = ( S_.v_m_ < P_.V_min_ ? P_.V_min_ : S_.v_m_ );
     }

--- a/models/eprop_iaf_psc_delta.cpp
+++ b/models/eprop_iaf_psc_delta.cpp
@@ -324,8 +324,7 @@ eprop_iaf_psc_delta::update( Time const& origin, const long from, const long to 
       }
 
       S_.v_m_ = V_.P_i_in_ * ( S_.i_in_ + P_.I_e_ ) + V_.P_v_m_ * S_.v_m_ + z_in;
-
-      S_.v_m_ = ( S_.v_m_ < P_.V_min_ ? P_.V_min_ : S_.v_m_ );
+      S_.v_m_ = std::max( S_.v_m_, P_.V_min_ );
     }
     else
     {

--- a/models/eprop_iaf_psc_delta.cpp
+++ b/models/eprop_iaf_psc_delta.cpp
@@ -286,7 +286,6 @@ eprop_iaf_psc_delta::pre_run_hook()
 
   V_.P_v_m_ = std::exp( -dt / P_.tau_m_ );
   V_.P_i_in_ = P_.tau_m_ / P_.C_m_ * ( 1.0 - V_.P_v_m_ );
-  V_.P_z_in_ = 1.0;
 }
 
 long
@@ -318,7 +317,7 @@ eprop_iaf_psc_delta::update( Time const& origin, const long from, const long to 
 
     if ( S_.r_ == 0 ) // not refractory, can spike
     {
-      S_.v_m_ = V_.P_i_in_ * ( S_.i_in_ + P_.I_e_ ) + V_.P_v_m_ * S_.v_m_ + V_.P_z_in_ * z_in;
+      S_.v_m_ = V_.P_i_in_ * ( S_.i_in_ + P_.I_e_ ) + V_.P_v_m_ * S_.v_m_ + z_in;
 
       if ( P_.with_refr_input_ and S_.refr_spikes_buffer_ != 0.0 )
       {
@@ -444,7 +443,7 @@ eprop_iaf_psc_delta::compute_gradient( const long t_spike,
     L = eprop_hist_it->learning_signal_;
     firing_rate_reg = eprop_hist_it->firing_rate_reg_;
 
-    z_bar = V_.P_v_m_ * z_bar + V_.P_z_in_ * z;
+    z_bar = V_.P_v_m_ * z_bar + z;
     e = psi * z_bar;
     e_bar = P_.kappa_ * e_bar + ( 1.0 - P_.kappa_ ) * e;
     e_bar_reg = P_.kappa_reg_ * e_bar_reg + ( 1.0 - P_.kappa_reg_ ) * e;

--- a/models/eprop_iaf_psc_delta.h
+++ b/models/eprop_iaf_psc_delta.h
@@ -543,10 +543,6 @@ private:
     //! Propagator matrix entry for evolving the membrane voltage (mathematical symbol "alpha" in user documentation).
     double P_v_m_;
 
-    //! Propagator matrix entry for evolving the incoming spike variables (mathematical symbol "zeta" in user
-    //! documentation).
-    double P_z_in_;
-
     //! Propagator matrix entry for evolving the incoming currents.
     double P_i_in_;
 

--- a/models/eprop_iaf_psc_delta_adapt.cpp
+++ b/models/eprop_iaf_psc_delta_adapt.cpp
@@ -359,8 +359,7 @@ eprop_iaf_psc_delta_adapt::update( Time const& origin, const long from, const lo
       }
 
       S_.v_m_ = V_.P_i_in_ * ( S_.i_in_ + P_.I_e_ ) + V_.P_v_m_ * S_.v_m_ + z_in;
-
-      S_.v_m_ = ( S_.v_m_ < P_.V_min_ ? P_.V_min_ : S_.v_m_ );
+      S_.v_m_ = std::max( S_.v_m_, P_.V_min_ );
     }
     else
     {

--- a/models/eprop_iaf_psc_delta_adapt.cpp
+++ b/models/eprop_iaf_psc_delta_adapt.cpp
@@ -348,17 +348,17 @@ eprop_iaf_psc_delta_adapt::update( Time const& origin, const long from, const lo
   {
     const long t = origin.get_steps() + lag;
 
-    const auto z_in = B_.spikes_.get_value( lag );
+    auto z_in = B_.spikes_.get_value( lag );
 
     if ( S_.r_ == 0 ) // not refractory, can spike
     {
-      S_.v_m_ = V_.P_i_in_ * ( S_.i_in_ + P_.I_e_ ) + V_.P_v_m_ * S_.v_m_ + z_in;
-
       if ( P_.with_refr_input_ and S_.refr_spikes_buffer_ != 0.0 )
       {
-        S_.v_m_ += S_.refr_spikes_buffer_;
+        z_in += S_.refr_spikes_buffer_;
         S_.refr_spikes_buffer_ = 0.0;
       }
+
+      S_.v_m_ = V_.P_i_in_ * ( S_.i_in_ + P_.I_e_ ) + V_.P_v_m_ * S_.v_m_ + z_in;
 
       S_.v_m_ = ( S_.v_m_ < P_.V_min_ ? P_.V_min_ : S_.v_m_ );
     }

--- a/models/eprop_iaf_psc_delta_adapt.cpp
+++ b/models/eprop_iaf_psc_delta_adapt.cpp
@@ -320,7 +320,6 @@ eprop_iaf_psc_delta_adapt::pre_run_hook()
 
   V_.P_v_m_ = std::exp( -dt / P_.tau_m_ );
   V_.P_i_in_ = P_.tau_m_ / P_.C_m_ * ( 1.0 - V_.P_v_m_ );
-  V_.P_z_in_ = 1.0;
   V_.P_adapt_ = std::exp( -dt / P_.adapt_tau_ );
 }
 
@@ -353,7 +352,7 @@ eprop_iaf_psc_delta_adapt::update( Time const& origin, const long from, const lo
 
     if ( S_.r_ == 0 ) // not refractory, can spike
     {
-      S_.v_m_ = V_.P_i_in_ * ( S_.i_in_ + P_.I_e_ ) + V_.P_v_m_ * S_.v_m_ + V_.P_z_in_ * z_in;
+      S_.v_m_ = V_.P_i_in_ * ( S_.i_in_ + P_.I_e_ ) + V_.P_v_m_ * S_.v_m_ + z_in;
 
       if ( P_.with_refr_input_ and S_.refr_spikes_buffer_ != 0.0 )
       {
@@ -483,7 +482,7 @@ eprop_iaf_psc_delta_adapt::compute_gradient( const long t_spike,
     L = eprop_hist_it->learning_signal_;
     firing_rate_reg = eprop_hist_it->firing_rate_reg_;
 
-    z_bar = V_.P_v_m_ * z_bar + V_.P_z_in_ * z;
+    z_bar = V_.P_v_m_ * z_bar + z;
     e = psi * ( z_bar - P_.adapt_beta_ * epsilon );
     epsilon = V_.P_adapt_ * epsilon + e;
     e_bar = P_.kappa_ * e_bar + ( 1.0 - P_.kappa_ ) * e;

--- a/models/eprop_iaf_psc_delta_adapt.h
+++ b/models/eprop_iaf_psc_delta_adapt.h
@@ -571,10 +571,6 @@ private:
     //! Propagator matrix entry for evolving the membrane voltage (mathematical symbol "alpha" in user documentation).
     double P_v_m_;
 
-    //! Propagator matrix entry for evolving the incoming spike variables (mathematical symbol "zeta" in user
-    //! documentation).
-    double P_z_in_;
-
     //! Propagator matrix entry for evolving the incoming currents.
     double P_i_in_;
 


### PR DESCRIPTION
This PR fixes one potential bug in the update function of the `eprop_iaf_psc_delta` models that is also present in the `iaf_psc_delta` model (49c70df7ec71ade3d292b8ef62894480db0d844d). Additionally, it proposes two changes to the models' update function to improve readability, with a possible minor increase in computational cost (9dfc46ecc38fd5991d4b0cd8b8bb1de1583a610b and a1ac3bdf47eebd1d15263df3587d24d435ea0b0e).